### PR TITLE
Making vi refresh faster

### DIFF
--- a/src/vi.c
+++ b/src/vi.c
@@ -905,24 +905,14 @@ void editorDrawStatusBar(struct abuf *ab) {
       break;
   }
 
-  len = sprintf(status, "%c %.20s - %d lines %s",
+  len = sprintf(status, "%c %.20s %s %d/%d\33K",
     mode,
-    E.filename ? E.filename : "[No Name]", E.numrows,
-    E.dirty ? "(modified)" : "");
-  rlen = sprintf(rstatus, "%d/%d", E.cy + 1, E.numrows);
-  if (len > E.screencols) len = E.screencols;
+    E.filename ? E.filename : "No file",
+    E.dirty ? "[Modified]" : "",
+    E.cy + 1, E.numrows);
   abAppendGotoxy(ab, 0, 22);
   abAppend(ab, status, len);
 
-  while (len < E.screencols) {
-    if (E.screencols - len - 1 == rlen) {
-      abAppend(ab, rstatus, rlen);
-      break;
-    } else {
-      abAppend(ab, " ", 1);
-      len++;
-    }
-  }
 }
 
 void editorDrawMessageBar(struct abuf *ab) {

--- a/src/vi.c
+++ b/src/vi.c
@@ -544,7 +544,7 @@ void editorRowInsertChar(erow *row, int at, int c) {
   printf("\33x5");
   putchar(c);
   if (at != row->size) {
-    for (n=at+1; n < row->size; n++) {
+    for (n=at; n < row->size; n++) {
       putchar(row->chars[n]);
     }
   }

--- a/src/vi.c
+++ b/src/vi.c
@@ -1105,6 +1105,8 @@ void editorMoveCursor(char key) {
     case ARROW_RIGHT:
       if (row && E.cx < row->size) {
         E.cx++;
+      } else if (E.mode == M_INSERT && E.cx == 0 && row->size == 0) {
+        E.cx++;
       } else if (row && E.cx == row->size && E.mode != M_COMMAND) {
         E.cy++;
         E.cx = 0;

--- a/src/vi.c
+++ b/src/vi.c
@@ -530,6 +530,10 @@ void editorFreeRow(erow *row) {
   free(row->chars);
 }
 void editorDelRow(int at) {
+
+  // Update screen
+  E.full_refresh = 1;
+
   if (at < 0 || at >= E.numrows) return;
   editorFreeRow(&E.row[at]);
   memmove(&E.row[at], &E.row[at + 1], sizeof(erow) * (E.numrows - at - 1));

--- a/src/vi.c
+++ b/src/vi.c
@@ -895,7 +895,8 @@ void editorDrawRows(struct abuf *ab) {
         while (padding--) abAppend(ab, " ", 1);
         abAppend(ab, welcome, welcomelen);
       } else {
-        abAppend(ab, "~", 1);
+        if (y>0)
+          abAppend(ab, "~", 1);
       }
     } else {
       len = E.row[filerow].rsize - E.coloff;

--- a/src/vi.c
+++ b/src/vi.c
@@ -841,15 +841,19 @@ void editorScroll() {
 
   if (E.cy < E.rowoff) {
     E.rowoff = E.cy;
+    E.full_refresh = 1;
   }
   if (E.cy >= E.rowoff + E.screenrows) {
     E.rowoff = E.cy - E.screenrows + 1;
+    E.full_refresh = 1;
   }
   if (E.rx < E.coloff) {
     E.coloff = E.rx;
+    E.full_refresh = 1;
   }
   if (E.rx >= E.coloff + E.screencols) {
     E.coloff = E.rx - E.screencols + 1;
+    E.full_refresh = 1;
   }
 }
 

--- a/src/vi.c
+++ b/src/vi.c
@@ -892,8 +892,8 @@ void editorDrawRows(struct abuf *ab) {
 }
 
 void editorDrawStatusBar(struct abuf *ab) {
-  char status[80], rstatus[80];
-  int len, rlen;
+  char status[80];
+  int len;
   char mode;
 
   switch (E.mode) {

--- a/src/vi.c
+++ b/src/vi.c
@@ -921,7 +921,6 @@ void editorDrawMessageBar(struct abuf *ab) {
   if (E.msgbar_updated) {
     E.msgbar_updated = 0;
     abAppendGotoxy(ab, 0, 23);
-    abAppend(ab, "\33K", 2);
     msglen = strlen(E.statusmsg);
     if (msglen > E.screencols) msglen = E.screencols;
     if (msglen) {
@@ -929,6 +928,7 @@ void editorDrawMessageBar(struct abuf *ab) {
       E.statusmsg[0] = '\0';
       E.msgbar_updated = 1;
     }
+    abAppend(ab, "\33K", 2);
   }
 }
 

--- a/src/vi.c
+++ b/src/vi.c
@@ -509,6 +509,10 @@ void editorUpdateRow(erow *row) {
 }
 
 void editorInsertRow(int at, char *s, size_t len) {
+
+  // Update screen
+  E.full_refresh = 1;
+
   if (at < 0 || at > E.numrows) return;
   E.row = realloc(E.row, sizeof(erow) * (E.numrows + 1));
   memmove(&E.row[at + 1], &E.row[at], sizeof(erow) * (E.numrows - at));

--- a/src/vi.c
+++ b/src/vi.c
@@ -1324,8 +1324,6 @@ int main(char **argv, int argc) {
     editorOpen(filename);
   }
 
-  editorSetStatusMessage("HELP: Ctrl-S = save | Ctrl-Q = quit");
-
   while (1) {
     editorRefreshScreen();
     editorProcessKeypress();

--- a/src/vi.c
+++ b/src/vi.c
@@ -540,14 +540,6 @@ void editorDelRow(int at) {
 void editorRowInsertChar(erow *row, int at, int c) {
   int n;
 
-  if (at < 0 || at > row->size) at = row->size;
-  row->chars = realloc(row->chars, row->size + 2);
-  memmove(&row->chars[at + 1], &row->chars[at], row->size - at + 1);
-  row->size++;
-  row->chars[at] = c;
-  editorUpdateRow(row);
-  E.dirty++;
-
   // Update screen
   printf("\33x5");
   putchar(c);
@@ -556,6 +548,14 @@ void editorRowInsertChar(erow *row, int at, int c) {
       putchar(row->chars[n]);
     }
   }
+
+  if (at < 0 || at > row->size) at = row->size;
+  row->chars = realloc(row->chars, row->size + 2);
+  memmove(&row->chars[at + 1], &row->chars[at], row->size - at + 1);
+  row->size++;
+  row->chars[at] = c;
+  editorUpdateRow(row);
+  E.dirty++;
 }
 
 void editorRowAppendString(erow *row, char *s, size_t len) {

--- a/src/vi.c
+++ b/src/vi.c
@@ -568,6 +568,17 @@ void editorRowAppendString(erow *row, char *s, size_t len) {
 }
 
 void editorRowDelChar(erow *row, int at) {
+  int n;
+
+  // Update screen
+  printf("\33x5\b");
+  if (at != row->size) {
+    for (n=at+1; n < row->size; n++) {
+      putchar(row->chars[n]);
+    }
+  }
+  printf("\33K");
+
   if (at < 0 || at >= row->size) return;
   memmove(&row->chars[at], &row->chars[at + 1], row->size - at);
   row->size--;


### PR DESCRIPTION
Instead of refreshing screen on every keypress, refresh only the required part.

CTRL-L still forces a full screen refresh